### PR TITLE
Ensure cosistent split of description for webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ The TipJar extension allows you to integrate Bitcoin Lightning (and on-chain) ti
 
 <h2>How to set it up</h2>
 
-1. Simply create a new Tip Jar with the desired details (onchain optional):  
+1. Simply create a new Tip Jar with the desired details (onchain and webhook optional):  
 ![image](https://user-images.githubusercontent.com/28876473/134996842-ec2f2783-2eef-4671-8eaf-023713865512.png)
 1. Share the URL you get from this little button:  
 ![image](https://user-images.githubusercontent.com/28876473/134996973-f8ed4632-ea2f-4b62-83f1-1e4c6b6c91fa.png)
 
+<h2>A note on webhooks</h3>
+
+The `description` field of the message POSTed to your webhook will be in the following format:
+ * `{length of the name}|{name}{message}`  
+
+You can split along the first `|`. This will give you the index at which to split between the name of the tipper and the message of the tipper.
 
 <h3>And that's it already! Let the sats flow!</h3>

--- a/views_api.py
+++ b/views_api.py
@@ -62,12 +62,11 @@ async def api_create_tip(data: createTips):
 
     name = data.name
 
-    # Ensure that description string can be split reliably
-    name = name.replace('"', "''")
     if not name:
         name = "Anonymous"
 
-    description = f"{name}: {message}"
+    # Ensure that description string can be split reliably
+    description = f"{len(name)}|{name}{message}"
     charge_id = await create_charge(
         data={
             "amount": sats,


### PR DESCRIPTION
Previously, it wasn't possible to reliably split the description into name and message, since the name could include `:`s. This change prepends the length of the `name` followed by a pipe. Splitting along the first pipe in the string now yields:
1. The length of the name (let's call it `len`)
2. The name, immediately followed by the message  
    (let's call it `joint_description`)  

Now the webhook receiver can set `name` to be `joint_description[:len]`, and `message` to be `joint_descritption[len:]`