### PR TITLE
allow name without extra splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,8 @@ The TipJar extension allows you to integrate Bitcoin Lightning (and on-chain) ti
 <h2>How to set it up</h2>
 
 1. Simply create a new Tip Jar with the desired details (onchain and webhook optional):  
-![image](https://user-images.githubusercontent.com/28876473/134996842-ec2f2783-2eef-4671-8eaf-023713865512.png)
+   ![image](https://user-images.githubusercontent.com/28876473/134996842-ec2f2783-2eef-4671-8eaf-023713865512.png)
 1. Share the URL you get from this little button:  
-![image](https://user-images.githubusercontent.com/28876473/134996973-f8ed4632-ea2f-4b62-83f1-1e4c6b6c91fa.png)
-
-<h2>A note on webhooks</h3>
-
-The `description` field of the message POSTed to your webhook will be in the following format:
- * `{length of the name}|{name}{message}`  
-
-You can split along the first `|`. This will give you the index at which to split between the name of the tipper and the message of the tipper.
+   ![image](https://user-images.githubusercontent.com/28876473/134996973-f8ed4632-ea2f-4b62-83f1-1e4c6b6c91fa.png)
 
 <h3>And that's it already! Let the sats flow!</h3>

--- a/views_api.py
+++ b/views_api.py
@@ -65,13 +65,12 @@ async def api_create_tip(data: createTips):
     if not name:
         name = "Anonymous"
 
-    # Ensure that description string can be split reliably
-    description = f"{len(name)}|{name}{message}"
     charge_id = await create_charge(
         data={
             "amount": sats,
             "webhook": tipjar.webhook or "",
-            "description": description,
+            "name": name,
+            "description": message,
             "onchainwallet": tipjar.onchain or "",
             "lnbitswallet": tipjar.wallet,
             "completelink": "/tipjar/" + str(tipjar_id),
@@ -136,7 +135,6 @@ async def api_update_tip(
             )
 
         if tip.wallet != wallet.wallet.id:
-
             raise HTTPException(
                 status_code=HTTPStatus.FORBIDDEN, detail="Not your tip."
             )
@@ -178,9 +176,7 @@ async def api_update_tipjar(
 
 
 @tipjar_ext.delete("/api/v1/tips/{tip_id}")
-async def api_delete_tip(
-    tip_id: str, wallet: WalletTypeInfo = Depends(get_key_type)
-):
+async def api_delete_tip(tip_id: str, wallet: WalletTypeInfo = Depends(get_key_type)):
     """Delete the tip with the given tip_id"""
     tip = await get_tip(tip_id)
     if not tip:
@@ -200,8 +196,7 @@ async def api_delete_tip(
 
 @tipjar_ext.delete("/api/v1/tipjars/{tipjar_id}")
 async def api_delete_tipjar(
-    tipjar_id: int,
-    wallet: WalletTypeInfo = Depends(get_key_type)
+    tipjar_id: int, wallet: WalletTypeInfo = Depends(get_key_type)
 ):
     """Delete the tipjar with the given tipjar_id"""
     tipjar = await get_tipjar(tipjar_id)
@@ -210,7 +205,6 @@ async def api_delete_tipjar(
             status_code=HTTPStatus.NOT_FOUND, detail="No tipjar with this ID!"
         )
     if tipjar.wallet != wallet.wallet.id:
-
         raise HTTPException(
             status_code=HTTPStatus.FORBIDDEN,
             detail="Not authorized to delete this tipjar!",


### PR DESCRIPTION
Allow the name to be sent without splits or extra symbols! Charge/Satspay webhook now sends the name key.

```
{
  "id": "ieWPbkuXmBDXixHxXX73aD",
  "name": "My Name",
  "description": "This my message to you!",
  "onchainaddress": null,
  "payment_request": "lnbc10u1pjnzzkmdp9...",
  "payment_hash": "ede3422b2c81b01daef8bfa3f...",
  "time": 1440,
  "amount": 1000,
  "zeroconf": false,
  "balance": 1000,
  "pending": 0,
  "paid": true,
  "timestamp": 1697712859,
  "time_elapsed": false,
  "time_left": 1432.4166666666667,
  "custom_css": "",
  "completelink": "/tipjar/1",
  "completelinktext": "Thanks for the tip!"
}
```

@Fittiboy :eyes: 